### PR TITLE
fix: 开放 Hasura 8080 端口对外访问

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
     ports:
-      - "127.0.0.1:${HASURA_PORT:-8080}:8080"
+      - "${HASURA_PORT:-8080}:8080"
     volumes:
       - ./hasura/metadata:/hasura-metadata:ro
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- 移除 Hasura 端口的 `127.0.0.1` 绑定限制
- 允许外部访问 Hasura GraphQL 控制台

## Test plan

- [x] 服务器已验证可通过 http://46.224.5.136:8080 访问

🤖 Generated with [Claude Code](https://claude.com/claude-code)